### PR TITLE
Add multi-BIN dialog management and admin controls

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -47,6 +47,7 @@ class LoginRequest(BaseModel):
 class ReplyRequest(BaseModel):
     chat_id: int
     text: str
+    dialog_id: int | None = None
 
 
 class UserResponse(BaseModel):
@@ -99,14 +100,18 @@ class MessageResponse(BaseModel):
     created_at: str
     section: str | None = None
     section_title: str | None = None
+    dialog_id: int | None = None
 
 
 class ChatResponse(BaseModel):
     chat_id: int
+    dialog_id: int
     title: str
     username: str | None
     type: str
     updated_at: str
+    dialog_started_at: str
+    dialog_closed_at: str | None = None
     section: str | None = None
     section_title: str | None = None
     bin: str | None = None
@@ -122,6 +127,7 @@ class NotificationResponse(BaseModel):
     section: str | None = None
     section_title: str | None = None
     bin: str | None = None
+    dialog_id: int | None = None
 
 
 def require_api_token(x_api_token: str | None = Header(default=None, alias="X-Api-Token")) -> None:
@@ -210,6 +216,7 @@ class ProfileUpdateRequest(BaseModel):
     job_title: str | None = Field(default=None, max_length=120)
     phone: str | None = Field(default=None, max_length=50)
     bio: str | None = Field(default=None, max_length=500)
+    email: EmailStr | None = None
 
 
 @router.put("/profile", response_model=UserResponse)
@@ -222,14 +229,19 @@ def update_profile(
         "job_title": request.job_title if request.job_title is not None else current_user.get("job_title", ""),
         "phone": request.phone if request.phone is not None else current_user.get("phone", ""),
         "bio": request.bio if request.bio is not None else current_user.get("bio", ""),
+        "email": request.email if request.email is not None else current_user.get("email"),
     }
-    updated = database.update_user_profile(
-        current_user["id"],
-        name=payload["name"],
-        job_title=payload["job_title"],
-        phone=payload["phone"],
-        bio=payload["bio"],
-    )
+    try:
+        updated = database.update_user_profile(
+            current_user["id"],
+            name=payload["name"],
+            job_title=payload["job_title"],
+            phone=payload["phone"],
+            bio=payload["bio"],
+            email=payload["email"],
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     return UserResponse(**updated)
 
 
@@ -338,6 +350,20 @@ def set_user_bins_endpoint(
     return UserResponse(**sanitized)
 
 
+@router.delete("/users/{user_id}")
+def delete_user_endpoint(
+    user_id: int,
+    current_admin: Dict[str, object] = Depends(require_admin),
+):
+    if user_id == current_admin["id"]:
+        raise HTTPException(status_code=400, detail="Нельзя удалить собственный аккаунт")
+    try:
+        database.delete_user(user_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return {"status": "ok"}
+
+
 @router.get("/roles")
 def list_roles(_: Dict[str, object] = Depends(require_admin)):
     return [
@@ -376,7 +402,14 @@ def list_chats(
         favorite_only=favorite_only,
         bin_query=bin_query,
     )
-    enriched = []
+    enriched: List[ChatResponse] = []
+    def _normalize(value: object, *, fallback: Optional[str] = None) -> str:
+        if value is None:
+            return fallback or datetime.utcnow().isoformat()
+        if isinstance(value, datetime):
+            return value.isoformat()
+        return str(value)
+
     for chat in chats:
         section_id = chat.get("section")
         section_title = None
@@ -384,7 +417,25 @@ def list_chats(
             section = next((s for s in database.SECTIONS if s["id"] == section_id), None)
             if section:
                 section_title = section["title"]
-        enriched.append({**chat, "section_title": section_title})
+        enriched.append(
+            ChatResponse(
+                chat_id=int(chat["chat_id"]),
+                dialog_id=int(chat["dialog_id"]),
+                title=str(chat["title"]),
+                username=chat.get("username"),
+                type=str(chat["type"]),
+                updated_at=_normalize(chat.get("updated_at")),
+                dialog_started_at=_normalize(chat.get("dialog_started_at")),
+                dialog_closed_at=
+                    _normalize(chat.get("dialog_closed_at"))
+                    if chat.get("dialog_closed_at")
+                    else None,
+                section=section_id,
+                section_title=section_title,
+                bin=chat.get("bin"),
+                is_favorite=bool(chat.get("is_favorite")),
+            )
+        )
     return enriched
 
 
@@ -392,28 +443,61 @@ def list_chats(
 def get_chat_messages(
     chat_id: int,
     limit: int = 50,
+    dialog_id: int | None = None,
     current_user: Dict[str, object] = Depends(get_current_user),
 ):
-    if not database.user_can_access_chat(current_user["id"], current_user["role"], chat_id):
+    if dialog_id is not None:
+        dialog = database.get_chat_dialog(dialog_id)
+        if dialog is None or dialog["chat_id"] != chat_id:
+            raise HTTPException(status_code=404, detail="Диалог не найден")
+    if not database.user_can_access_chat(
+        current_user["id"], current_user["role"], chat_id, dialog_id
+    ):
         raise HTTPException(status_code=403, detail="Нет доступа к диалогу")
     allowed_sections = None
     if current_user["role"] != database.ROLE_ADMIN:
         allowed_sections = current_user.get("sections") or []
-    messages = database.get_messages(chat_id, limit=limit, allowed_sections=allowed_sections)
+    messages = database.get_messages(
+        chat_id,
+        limit=limit,
+        allowed_sections=allowed_sections,
+        dialog_id=dialog_id,
+    )
+    result: List[MessageResponse] = []
     for message in messages:
         section_id = message.get("section")
+        section_title = None
         if section_id:
             section = next((s for s in database.SECTIONS if s["id"] == section_id), None)
             if section:
-                message["section_title"] = section["title"]
-    return messages
+                section_title = section["title"]
+        result.append(
+            MessageResponse(
+                id=int(message["id"]),
+                chat_id=int(message["chat_id"]),
+                direction=str(message["direction"]),
+                text=str(message["text"]),
+                author=message.get("author"),
+                created_at=str(message["created_at"]),
+                section=section_id,
+                section_title=section_title,
+                dialog_id=message.get("dialog_id"),
+            )
+        )
+    return result
 
 
 @router.post("/messages/send")
 def send_message(request: ReplyRequest, current_user: Dict[str, object] = Depends(get_current_user)):
     if current_user["role"] not in (database.ROLE_ADMIN, database.ROLE_MODERATOR):
         raise HTTPException(status_code=403, detail="Недостаточно прав для отправки сообщений")
-    if not database.user_can_access_chat(current_user["id"], current_user["role"], request.chat_id):
+    if request.dialog_id is not None:
+        dialog = database.get_chat_dialog(request.dialog_id)
+        if dialog is None or dialog["chat_id"] != request.chat_id:
+            raise HTTPException(status_code=404, detail="Диалог не найден")
+    if not database.user_can_access_chat(
+        current_user["id"], current_user["role"], request.chat_id, request.dialog_id
+    ):
         raise HTTPException(status_code=403, detail="Нет доступа к выбранному диалогу")
     if not request.text.strip():
         raise HTTPException(status_code=400, detail="Message text can not be empty")
@@ -426,6 +510,7 @@ def send_message(request: ReplyRequest, current_user: Dict[str, object] = Depend
     section = None
     if chat:
         section = chat.get("section")
+    resolved_dialog_id = request.dialog_id or database.get_active_chat_dialog_id(request.chat_id)
     database.save_message(
         chat_id=request.chat_id,
         direction="outgoing",
@@ -436,8 +521,14 @@ def send_message(request: ReplyRequest, current_user: Dict[str, object] = Depend
         username=sent_message.chat.username,
         chat_type=sent_message.chat.type,
         section=section,
+        dialog_id=resolved_dialog_id,
     )
-    return {"status": "ok", "message_id": sent_message.message_id, "operator": current_user["name"]}
+    return {
+        "status": "ok",
+        "message_id": sent_message.message_id,
+        "operator": current_user["name"],
+        "dialog_id": resolved_dialog_id,
+    }
 
 
 @router.post("/chats/{chat_id}/favorite")
@@ -465,17 +556,25 @@ def unmark_chat_favorite(
 @router.delete("/chats/{chat_id}")
 def delete_chat_endpoint(
     chat_id: int,
-    current_user: Dict[str, object] = Depends(get_current_user),
+    _: Dict[str, object] = Depends(require_admin),
 ):
-    if current_user["role"] not in (database.ROLE_ADMIN, database.ROLE_MODERATOR):
-        raise HTTPException(status_code=403, detail="Недостаточно прав для удаления диалога")
     chat = database.get_chat(chat_id)
     if chat is None:
         raise HTTPException(status_code=404, detail="Диалог не найден")
-    if not database.user_can_access_chat(current_user["id"], current_user["role"], chat_id):
-        raise HTTPException(status_code=403, detail="Нет доступа к диалогу")
     try:
         database.delete_chat(chat_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return {"status": "ok"}
+
+
+@router.delete("/dialogs/{dialog_id}")
+def delete_dialog_endpoint(
+    dialog_id: int,
+    _: Dict[str, object] = Depends(require_admin),
+):
+    try:
+        database.delete_chat_dialog(dialog_id)
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     return {"status": "ok"}
@@ -518,6 +617,7 @@ def list_updates(
                     section=section_id,
                     section_title=section_title,
                     bin=entry.get("bin"),
+                    dialog_id=entry.get("dialog_id"),
                 )
             )
             continue
@@ -549,6 +649,7 @@ def list_updates(
                     section=entry.get("section"),
                     section_title=None,
                     bin=entry.get("bin"),
+                    dialog_id=entry.get("dialog_id"),
                 )
             )
     return enriched

--- a/backend/database.py
+++ b/backend/database.py
@@ -54,6 +54,19 @@ def _init_db() -> None:
         )
         _connection.execute(
             """
+            CREATE TABLE IF NOT EXISTS chat_dialogs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                chat_id INTEGER NOT NULL,
+                bin TEXT NOT NULL,
+                started_at TEXT NOT NULL,
+                ended_at TEXT,
+                last_message_at TEXT,
+                FOREIGN KEY(chat_id) REFERENCES chats(chat_id) ON DELETE CASCADE
+            )
+            """
+        )
+        _connection.execute(
+            """
             CREATE TABLE IF NOT EXISTS messages (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 chat_id INTEGER NOT NULL,
@@ -63,7 +76,9 @@ def _init_db() -> None:
                 author TEXT,
                 created_at TEXT NOT NULL,
                 section TEXT,
-                FOREIGN KEY(chat_id) REFERENCES chats(chat_id)
+                dialog_id INTEGER,
+                FOREIGN KEY(chat_id) REFERENCES chats(chat_id),
+                FOREIGN KEY(dialog_id) REFERENCES chat_dialogs(id) ON DELETE SET NULL
             )
             """
         )
@@ -143,6 +158,8 @@ def _init_db() -> None:
     _ensure_column("chats", "section", "TEXT")
     _ensure_column("chats", "bin", "TEXT")
     _ensure_column("messages", "section", "TEXT")
+    _ensure_column("messages", "dialog_id", "INTEGER")
+    _ensure_column("chat_dialogs", "last_message_at", "TEXT")
     _ensure_column("users", "job_title", "TEXT")
     _ensure_column("users", "phone", "TEXT")
     _ensure_column("users", "bio", "TEXT")
@@ -158,6 +175,7 @@ def _init_db() -> None:
         )
 
     _ensure_admin_account()
+    _ensure_chat_dialog_records()
 
 
 def _ensure_column(table: str, column: str, definition: str) -> None:
@@ -212,6 +230,32 @@ def _ensure_admin_account() -> None:
     )
 
 
+def _ensure_chat_dialog_records() -> None:
+    with _lock, _connection:
+        rows = _connection.execute(
+            """
+            SELECT chat_id, bin, updated_at
+            FROM chats
+            WHERE bin IS NOT NULL AND TRIM(bin) != ''
+            """
+        ).fetchall()
+        for row in rows:
+            exists = _connection.execute(
+                "SELECT 1 FROM chat_dialogs WHERE chat_id = ? LIMIT 1",
+                (row["chat_id"],),
+            ).fetchone()
+            if exists:
+                continue
+            updated_at = row["updated_at"] or datetime.utcnow().isoformat()
+            _connection.execute(
+                """
+                INSERT INTO chat_dialogs (chat_id, bin, started_at, last_message_at)
+                VALUES (?, ?, ?, ?)
+                """,
+                (row["chat_id"], row["bin"], updated_at, updated_at),
+            )
+
+
 _init_db()
 
 
@@ -257,6 +301,7 @@ class Message:
     author: str | None
     created_at: datetime
     section: str | None
+    dialog_id: int | None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Message":
@@ -269,6 +314,7 @@ class Message:
             author=row["author"],
             created_at=datetime.fromisoformat(row["created_at"]),
             section=row["section"],
+            dialog_id=row["dialog_id"],
         )
 
 
@@ -300,17 +346,81 @@ def save_message(
     username: str | None,
     chat_type: str,
     section: str | None,
+    dialog_id: int | None = None,
 ) -> None:
     now = datetime.utcnow().isoformat()
+    resolved_dialog_id = dialog_id
+    if resolved_dialog_id is None:
+        active_dialog = get_active_chat_dialog(chat_id)
+        if active_dialog:
+            resolved_dialog_id = active_dialog["id"]
     with _lock, _connection:
         _connection.execute(
             """
-            INSERT INTO messages (chat_id, direction, text, message_id, author, created_at, section)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO messages (chat_id, direction, text, message_id, author, created_at, section, dialog_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (chat_id, direction, text, message_id, author, now, section),
+            (chat_id, direction, text, message_id, author, now, section, resolved_dialog_id),
         )
+        if resolved_dialog_id is not None:
+            _connection.execute(
+                "UPDATE chat_dialogs SET last_message_at = ? WHERE id = ?",
+                (now, resolved_dialog_id),
+            )
     upsert_chat(chat_id, chat_title, username, chat_type)
+
+
+def get_chat_dialog(dialog_id: int) -> Optional[Dict[str, object]]:
+    with _lock, _connection:
+        row = _connection.execute(
+            """
+            SELECT id, chat_id, bin, started_at, ended_at, last_message_at
+            FROM chat_dialogs
+            WHERE id = ?
+            """,
+            (dialog_id,),
+        ).fetchone()
+    if row is None:
+        return None
+    return {
+        "id": row["id"],
+        "chat_id": row["chat_id"],
+        "bin": row["bin"],
+        "started_at": row["started_at"],
+        "ended_at": row["ended_at"],
+        "last_message_at": row["last_message_at"],
+    }
+
+
+def get_active_chat_dialog(chat_id: int) -> Optional[Dict[str, object]]:
+    with _lock, _connection:
+        row = _connection.execute(
+            """
+            SELECT id, chat_id, bin, started_at, ended_at, last_message_at
+            FROM chat_dialogs
+            WHERE chat_id = ? AND ended_at IS NULL
+            ORDER BY started_at DESC
+            LIMIT 1
+            """,
+            (chat_id,),
+        ).fetchone()
+    if row is None:
+        return None
+    return {
+        "id": row["id"],
+        "chat_id": row["chat_id"],
+        "bin": row["bin"],
+        "started_at": row["started_at"],
+        "ended_at": row["ended_at"],
+        "last_message_at": row["last_message_at"],
+    }
+
+
+def get_active_chat_dialog_id(chat_id: int) -> int | None:
+    dialog = get_active_chat_dialog(chat_id)
+    if dialog is None:
+        return None
+    return int(dialog["id"])
 
 
 def list_chats_for_user(
@@ -321,9 +431,21 @@ def list_chats_for_user(
     bin_query: str | None = None,
 ) -> List[dict]:
     query_parts = [
-        "SELECT c.chat_id, c.title, c.username, c.type, c.updated_at, c.section, c.bin,",
-        "       f.user_id AS fav_user_id",
-        "FROM chats c",
+        "SELECT",
+        "  c.chat_id,",
+        "  c.title,",
+        "  c.username,",
+        "  c.type,",
+        "  c.section,",
+        "  c.updated_at AS chat_updated_at,",
+        "  cd.id AS dialog_id,",
+        "  cd.bin AS dialog_bin,",
+        "  cd.started_at AS dialog_started_at,",
+        "  cd.ended_at AS dialog_ended_at,",
+        "  cd.last_message_at AS dialog_last_message_at,",
+        "  f.user_id AS fav_user_id",
+        "FROM chat_dialogs cd",
+        "JOIN chats c ON c.chat_id = cd.chat_id",
         "LEFT JOIN favorites f ON f.chat_id = c.chat_id AND f.user_id = ?",
     ]
     params: List[object] = [user_id]
@@ -333,29 +455,49 @@ def list_chats_for_user(
         assigned_bins = get_user_bins(user_id)
         if not allowed_sections or not assigned_bins:
             return []
-        placeholders = ",".join("?" for _ in allowed_sections)
-        filters.append(f"c.section IN ({placeholders})")
+        section_placeholders = ",".join("?" for _ in allowed_sections)
+        filters.append(f"c.section IN ({section_placeholders})")
         params.extend(allowed_sections)
         bin_placeholders = ",".join("?" for _ in assigned_bins)
-        filters.append(f"c.bin IN ({bin_placeholders})")
+        filters.append(f"cd.bin IN ({bin_placeholders})")
         params.extend(assigned_bins)
     if favorite_only:
         filters.append("f.user_id IS NOT NULL")
     if bin_query:
-        filters.append("c.bin LIKE ?")
+        filters.append("cd.bin LIKE ?")
         params.append(f"%{bin_query.strip()}%")
     if filters:
         query_parts.append("WHERE " + " AND ".join(filters))
-    query_parts.append("ORDER BY c.updated_at DESC")
+    query_parts.append(
+        "ORDER BY COALESCE(cd.last_message_at, c.updated_at, cd.started_at) DESC"
+    )
     sql = "\n".join(query_parts)
     with _lock, _connection:
         rows = _connection.execute(sql, params).fetchall()
     chats: List[dict] = []
     for row in rows:
-        chat = dict(asdict(Chat.from_row(row)))
-        chat["updated_at"] = chat["updated_at"].isoformat()
-        chat["is_favorite"] = bool(row["fav_user_id"])
-        chats.append(chat)
+        updated_raw = (
+            row["dialog_last_message_at"]
+            or row["chat_updated_at"]
+            or row["dialog_started_at"]
+        )
+        if not updated_raw:
+            updated_raw = datetime.utcnow().isoformat()
+        chats.append(
+            {
+                "chat_id": row["chat_id"],
+                "dialog_id": row["dialog_id"],
+                "title": row["title"],
+                "username": row["username"],
+                "type": row["type"],
+                "updated_at": updated_raw,
+                "dialog_started_at": row["dialog_started_at"],
+                "dialog_closed_at": row["dialog_ended_at"],
+                "section": row["section"],
+                "bin": row["dialog_bin"],
+                "is_favorite": bool(row["fav_user_id"]),
+            }
+        )
     return chats
 
 
@@ -363,13 +505,18 @@ def get_messages(
     chat_id: int,
     limit: int = 50,
     allowed_sections: Optional[Iterable[str]] = None,
+    *,
+    dialog_id: int | None = None,
 ) -> List[dict]:
     query_parts = [
-        "SELECT id, chat_id, direction, text, message_id, author, created_at, section",
+        "SELECT id, chat_id, direction, text, message_id, author, created_at, section, dialog_id",
         "FROM messages",
         "WHERE chat_id = ?",
     ]
     params: List[object] = [chat_id]
+    if dialog_id is not None:
+        query_parts.append("AND dialog_id = ?")
+        params.append(dialog_id)
     if allowed_sections is not None:
         allowed_list = [section for section in allowed_sections if section]
         if allowed_list:
@@ -402,12 +549,46 @@ def set_chat_section(chat_id: int, section: str | None) -> None:
         )
 
 
-def set_chat_bin(chat_id: int, bin_value: str | None) -> None:
+def set_chat_bin(chat_id: int, bin_value: str | None) -> int | None:
+    normalized = (bin_value or "").strip()
+    now = datetime.utcnow().isoformat()
     with _lock, _connection:
+        if not normalized:
+            _connection.execute(
+                """
+                UPDATE chats
+                SET bin = NULL, section = NULL, updated_at = ?
+                WHERE chat_id = ?
+                """,
+                (now, chat_id),
+            )
+            _connection.execute(
+                "UPDATE chat_dialogs SET ended_at = COALESCE(ended_at, ?) WHERE chat_id = ? AND ended_at IS NULL",
+                (now, chat_id),
+            )
+            return None
+
         _connection.execute(
-            "UPDATE chats SET bin = ? WHERE chat_id = ?",
-            (bin_value, chat_id),
+            "UPDATE chat_dialogs SET ended_at = ? WHERE chat_id = ? AND ended_at IS NULL",
+            (now, chat_id),
         )
+        _connection.execute(
+            """
+            INSERT INTO chat_dialogs (chat_id, bin, started_at, last_message_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            (chat_id, normalized, now, now),
+        )
+        dialog_id_row = _connection.execute("SELECT last_insert_rowid()").fetchone()
+        _connection.execute(
+            """
+            UPDATE chats
+            SET bin = ?, section = NULL, updated_at = ?
+            WHERE chat_id = ?
+            """,
+            (normalized, now, chat_id),
+        )
+    return int(dialog_id_row[0]) if dialog_id_row else None
 
 
 def get_chat(chat_id: int) -> Optional[Dict[str, object]]:
@@ -502,6 +683,13 @@ def set_user_bins(user_id: int, bins: Iterable[str], *, assigned_by: int | None 
             created_at=now,
         )
     return sorted(new_values)
+
+
+def delete_user(user_id: int) -> None:
+    with _lock, _connection:
+        cursor = _connection.execute("DELETE FROM users WHERE id = ?", (user_id,))
+        if cursor.rowcount == 0:
+            raise ValueError("Пользователь не найден")
 
 
 def list_favorite_chat_ids(user_id: int) -> List[int]:
@@ -614,7 +802,42 @@ def delete_chat(chat_id: int) -> None:
             raise ValueError("Chat not found")
         _connection.execute("DELETE FROM messages WHERE chat_id = ?", (chat_id,))
         _connection.execute("DELETE FROM favorites WHERE chat_id = ?", (chat_id,))
+        _connection.execute("DELETE FROM chat_dialogs WHERE chat_id = ?", (chat_id,))
         _connection.execute("DELETE FROM chats WHERE chat_id = ?", (chat_id,))
+
+
+def delete_chat_dialog(dialog_id: int) -> None:
+    with _lock, _connection:
+        dialog_row = _connection.execute(
+            "SELECT id, chat_id FROM chat_dialogs WHERE id = ?",
+            (dialog_id,),
+        ).fetchone()
+        if dialog_row is None:
+            raise ValueError("Диалог не найден")
+        chat_id = dialog_row["chat_id"]
+        _connection.execute("DELETE FROM messages WHERE dialog_id = ?", (dialog_id,))
+        _connection.execute("DELETE FROM chat_dialogs WHERE id = ?", (dialog_id,))
+        latest = _connection.execute(
+            """
+            SELECT bin, started_at, last_message_at
+            FROM chat_dialogs
+            WHERE chat_id = ?
+            ORDER BY started_at DESC
+            LIMIT 1
+            """,
+            (chat_id,),
+        ).fetchone()
+        if latest:
+            timestamp = latest["last_message_at"] or latest["started_at"] or datetime.utcnow().isoformat()
+            _connection.execute(
+                "UPDATE chats SET bin = ?, updated_at = ? WHERE chat_id = ?",
+                (latest["bin"], timestamp, chat_id),
+            )
+        else:
+            _connection.execute(
+                "UPDATE chats SET bin = NULL, section = NULL WHERE chat_id = ?",
+                (chat_id,),
+            )
 
 
 def _row_to_user(row: sqlite3.Row | None) -> dict | None:
@@ -784,16 +1007,20 @@ def update_user_profile(
     job_title: str,
     phone: str,
     bio: str,
+    email: str | None,
 ) -> dict:
     with _lock, _connection:
-        _connection.execute(
-            """
-            UPDATE users
-            SET name = ?, job_title = ?, phone = ?, bio = ?
-            WHERE id = ?
-            """,
-            (name, job_title, phone, bio, user_id),
-        )
+        try:
+            _connection.execute(
+                """
+                UPDATE users
+                SET name = ?, job_title = ?, phone = ?, bio = ?, email = ?
+                WHERE id = ?
+                """,
+                (name, job_title, phone, bio, email or "", user_id),
+            )
+        except sqlite3.IntegrityError as exc:
+            raise ValueError("Адрес электронной почты уже используется") from exc
     return _sanitize_user_payload(get_user_by_id(user_id))
 
 
@@ -903,14 +1130,25 @@ def list_faq(section: str | None = None) -> List[dict]:
     return list(FAQ_ENTRIES)
 
 
-def user_can_access_chat(user_id: int, role: str, chat_id: int) -> bool:
+def user_can_access_chat(
+    user_id: int,
+    role: str,
+    chat_id: int,
+    dialog_id: int | None = None,
+) -> bool:
     if role == ROLE_ADMIN:
         return True
+    dialog_bin = None
+    if dialog_id is not None:
+        dialog = get_chat_dialog(dialog_id)
+        if dialog is None or dialog["chat_id"] != chat_id:
+            return False
+        dialog_bin = dialog.get("bin")
     chat = get_chat(chat_id)
     if chat is None:
         return False
     section = chat.get("section")
-    chat_bin = chat.get("bin")
+    chat_bin = dialog_bin or chat.get("bin")
     if section is None or chat_bin is None:
         return False
     allowed = set(get_user_sections(user_id))
@@ -932,7 +1170,7 @@ def list_updates_since(
     params: List[object] = []
     if role == ROLE_ADMIN or (allowed_sections and assigned_bins):
         query_parts = [
-            "SELECT m.id, m.chat_id, m.text, m.created_at, m.section, c.title, c.bin",
+            "SELECT m.id, m.chat_id, m.text, m.created_at, m.section, m.dialog_id, c.title, c.bin",
             "FROM messages m",
             "JOIN chats c ON c.chat_id = m.chat_id",
             "WHERE m.direction = 'incoming'",
@@ -964,6 +1202,7 @@ def list_updates_since(
                     "created_at": created_at,
                     "section": row["section"],
                     "bin": row["bin"],
+                    "dialog_id": row["dialog_id"],
                 }
             )
     notification_rows = list_notifications_since(user_id, since)

--- a/backend/telegram_bot.py
+++ b/backend/telegram_bot.py
@@ -294,24 +294,38 @@ def handle_updates(message: telebot.types.Message) -> None:
             _persist_message(message, direction="incoming", override_text="[ЗАПРОС ОПЕРАТОРА]", section=None)
             return
 
-    # Стандартная логика обработки БИНа и разделов
-    if chat_record and not chat_record.get("bin"):
-        if message.content_type != "text":
-            bot.send_message(chat.id, "Отправьте БИН организации числом из 12 цифр.")
-            _persist_message(message, direction="incoming", override_text=_humanize_message(message), section=None)
-            return
-        if BIN_PATTERN.match(text.strip()):
-            database.set_chat_bin(chat.id, text.strip())
-            bot.send_message(chat.id, f"Спасибо! БИН {text.strip()} сохранён.")
-            bot.send_message(
-                chat.id, 
-                "Теперь выберите подходящий раздел.\n\n"
-                "🤖 AI помощник автоматически включен и готов отвечать на ваши вопросы!",
-                reply_markup=_section_keyboard()
-            )
+    normalized_text = (text or "").strip()
+    is_text_message = message.content_type == "text"
+    is_bin_message = is_text_message and BIN_PATTERN.match(normalized_text)
+
+    # Требуем БИН, если он ещё не указан
+    if chat_record and not chat_record.get("bin") and not is_bin_message:
+        bot.send_message(chat.id, "Отправьте БИН организации числом из 12 цифр.")
+        if is_text_message:
+            _persist_message(message, direction="incoming", section=None)
         else:
-            bot.send_message(chat.id, "БИН должен содержать 12 цифр без пробелов. Попробуйте ещё раз.")
-        _persist_message(message, direction="incoming", section=None)
+            _persist_message(
+                message,
+                direction="incoming",
+                override_text=_humanize_message(message),
+                section=None,
+            )
+        return
+
+    if is_bin_message:
+        was_empty_bin = not chat_record or not chat_record.get("bin")
+        dialog_id = database.set_chat_bin(chat.id, normalized_text)
+        if was_empty_bin:
+            bot.send_message(chat.id, f"Спасибо! БИН {normalized_text} сохранён.")
+        else:
+            bot.send_message(chat.id, f"БИН обновлён. Открыт новый диалог для {normalized_text}.")
+        bot.send_message(
+            chat.id,
+            "Теперь выберите подходящий раздел.\n\n"
+            "🤖 AI помощник автоматически включен и готов отвечать на ваши вопросы!",
+            reply_markup=_section_keyboard(),
+        )
+        _persist_message(message, direction="incoming", section=None, dialog_id=dialog_id)
         return
 
     # Обработка разделов и FAQ
@@ -391,7 +405,8 @@ def _persist_message(
     direction: str,
     override_text: str | None = None,
     section: Optional[str] = None,
-    author: Optional[str] = None
+    author: Optional[str] = None,
+    dialog_id: Optional[int] = None,
 ) -> None:
     chat = message.chat
     text = override_text if override_text is not None else _humanize_message(message)
@@ -410,6 +425,7 @@ def _persist_message(
         username=chat.username,
         chat_type=chat.type,
         section=section,
+        dialog_id=dialog_id,
     )
     logger.info("Stored %s message from chat %s", direction, chat.id)
 

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite --host",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview --host 0.0.0.0 --port 4173"
   },
   "dependencies": {
     "react": "^18.3.1",

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -13,16 +13,19 @@ const App: React.FC = () => {
   const [activeTab, setActiveTab] = useState<TabKey>('dialogs');
 
   const currentUser = session?.user ?? null;
-  const availableTabs = useMemo(() => {
+  const navigationTabs = useMemo(() => {
     if (!currentUser) return [] as TabKey[];
-    return currentUser.isAdmin ? tabs.slice() : (['dialogs', 'profile'] as TabKey[]);
+    return currentUser.isAdmin ? (['dialogs', 'admin'] as TabKey[]) : (['dialogs'] as TabKey[]);
   }, [currentUser]);
 
   useEffect(() => {
-    if (!availableTabs.includes(activeTab) && availableTabs.length > 0) {
-      setActiveTab(availableTabs[0]);
+    if (activeTab === 'profile') {
+      return;
     }
-  }, [activeTab, availableTabs]);
+    if (!navigationTabs.includes(activeTab) && navigationTabs.length > 0) {
+      setActiveTab(navigationTabs[0]);
+    }
+  }, [activeTab, navigationTabs]);
 
   if (!session) {
     return <AuthPage onAuthenticated={setSession} apiClient={apiClient} />;
@@ -61,7 +64,7 @@ const App: React.FC = () => {
         </div>
 
         <nav className="tab-bar">
-          {availableTabs.map((tab) => (
+          {navigationTabs.map((tab) => (
             <button
               key={tab}
               className={`tab-button ${activeTab === tab ? 'active' : ''}`}

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -5,27 +5,32 @@ import AdminPage from './pages/AdminPage';
 import ProfilePage from './pages/ProfilePage';
 import { useApi } from './context/ApiContext';
 
-const tabs = ['dialogs', 'admin', 'profile'] as const;
-type TabKey = (typeof tabs)[number];
+type TabKey = 'dialogs' | 'admin' | 'profile';
+type NavTabKey = Exclude<TabKey, 'profile'>;
 
 const App: React.FC = () => {
   const { session, apiClient, setSession, logout } = useApi();
   const [activeTab, setActiveTab] = useState<TabKey>('dialogs');
 
   const currentUser = session?.user ?? null;
-  const navigationTabs = useMemo(() => {
-    if (!currentUser) return [] as TabKey[];
-    return currentUser.isAdmin ? (['dialogs', 'admin'] as TabKey[]) : (['dialogs'] as TabKey[]);
+  const navigationTabs = useMemo<NavTabKey[]>(() => {
+    if (!currentUser) return [];
+    return currentUser.isAdmin ? ['dialogs', 'admin'] : ['dialogs'];
   }, [currentUser]);
 
   useEffect(() => {
     if (activeTab === 'profile') {
       return;
     }
-    if (!navigationTabs.includes(activeTab) && navigationTabs.length > 0) {
+    if (navigationTabs.length > 0 && !navigationTabs.includes(activeTab as NavTabKey)) {
       setActiveTab(navigationTabs[0]);
     }
   }, [activeTab, navigationTabs]);
+
+  const tabLabels: Record<NavTabKey, string> = useMemo(
+    () => ({ dialogs: 'Диалоги', admin: 'Администрирование' }),
+    [],
+  );
 
   if (!session) {
     return <AuthPage onAuthenticated={setSession} apiClient={apiClient} />;
@@ -71,9 +76,7 @@ const App: React.FC = () => {
               onClick={() => setActiveTab(tab)}
               type="button"
             >
-              {tab === 'dialogs' && 'Диалоги'}
-              {tab === 'admin' && 'Администрирование'}
-              {tab === 'profile' && 'Профиль'}
+              {tabLabels[tab]}
             </button>
           ))}
         </nav>

--- a/webapp/src/api/ApiClient.ts
+++ b/webapp/src/api/ApiClient.ts
@@ -21,7 +21,10 @@ export class ApiError extends Error {
   }
 }
 
-const DEFAULT_BASE_URL = 'https://exclamatorily-nonaffecting-chelsey.ngrok-free.dev';
+const DEFAULT_BASE_URL =
+  typeof window !== 'undefined' && window.location
+    ? window.location.origin
+    : 'http://localhost:8000';
 const DEFAULT_API_TOKEN = 'MySecretTokenSayCheese';
 
 export interface ApiClientOptions {
@@ -238,12 +241,13 @@ export class ApiClient {
     return profile;
   }
 
-  async updateProfile(payload: { name?: string; jobTitle?: string; phone?: string; bio?: string }): Promise<UserProfile> {
+  async updateProfile(payload: { name?: string; jobTitle?: string; phone?: string; bio?: string; email?: string }): Promise<UserProfile> {
     const body = {
       name: payload.name,
       job_title: payload.jobTitle,
       phone: payload.phone,
       bio: payload.bio,
+      email: payload.email,
     };
     const response = await this.request<UserProfileRaw>('profile', {
       method: 'PUT',
@@ -286,19 +290,18 @@ export class ApiClient {
     return response.map(mapChatSummary);
   }
 
-  async fetchMessages(chatId: number, limit = 50): Promise<Message[]> {
+  async fetchMessages(chatId: number, limit = 50, dialogId?: number): Promise<Message[]> {
     const response = await this.request<MessageRaw[]>(`chats/${chatId}/messages`, {
       method: 'GET',
-      query: { limit },
+      query: { limit, dialog_id: dialogId },
     });
     return response.map(mapMessage);
   }
 
-  async sendMessage(chatId: number, text: string): Promise<void> {
+  async sendMessage(chatId: number, text: string, dialogId?: number): Promise<void> {
     await this.request('messages/send', {
       method: 'POST',
-      body: JSON.stringify({ chat_id: chatId, text }),
-      expectJson: false,
+      body: JSON.stringify({ chat_id: chatId, text, dialog_id: dialogId }),
     });
   }
 
@@ -318,16 +321,11 @@ export class ApiClient {
     }
   }
 
-  async deleteChat(chatId: number): Promise<void> {
-    await this.request(`chats/${chatId}`, {
+  async deleteDialog(dialogId: number): Promise<void> {
+    await this.request(`dialogs/${dialogId}`, {
       method: 'DELETE',
       expectJson: false,
     });
-    if (this.currentUserProfile) {
-      const favoriteSet = new Set(this.currentUserProfile.favoriteChatIds);
-      favoriteSet.delete(chatId);
-      this.updateCurrentUser({ ...this.currentUserProfile, favoriteChatIds: Array.from(favoriteSet) });
-    }
   }
 
   async fetchUsers(query?: string): Promise<UserProfile[]> {
@@ -336,6 +334,13 @@ export class ApiClient {
       query: query ? { query } : undefined,
     });
     return response.map(mapUserProfile);
+  }
+
+  async deleteUser(userId: number): Promise<void> {
+    await this.request(`users/${userId}`, {
+      method: 'DELETE',
+      expectJson: false,
+    });
   }
 
   async fetchRoles(): Promise<RoleInfo[]> {

--- a/webapp/src/api/ApiClient.ts
+++ b/webapp/src/api/ApiClient.ts
@@ -322,6 +322,9 @@ export class ApiClient {
   }
 
   async deleteDialog(dialogId: number): Promise<void> {
+    if (!this.currentUserProfile?.isAdmin) {
+      throw new ApiError('Удаление диалогов доступно только администраторам.', 403);
+    }
     await this.request(`dialogs/${dialogId}`, {
       method: 'DELETE',
       expectJson: false,

--- a/webapp/src/components/ConfirmModal.tsx
+++ b/webapp/src/components/ConfirmModal.tsx
@@ -25,8 +25,27 @@ const ConfirmModal: React.FC<ConfirmModalProps> = ({
   onCancel,
 }) => {
   const confirmClass = tone === 'danger' ? 'button danger' : 'button';
+  const icon =
+    tone === 'danger' ? (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path
+          d="M9.4 3.2a1 1 0 0 0-.94.68L8 5H5a1 1 0 1 0 0 2h1.08l1.3 12.38A2 2 0 0 0 9.36 21h5.28a2 2 0 0 0 1.98-1.62L17.92 7H19a1 1 0 1 0 0-2h-3l-.46-1.12A1 1 0 0 0 14.64 3h-5.2ZM9 7h6l-1.2 11h-3.6L9 7Zm2 2v7a1 1 0 0 0 2 0V9a1 1 0 1 0-2 0Z"
+          fill="currentColor"
+        />
+      </svg>
+    ) : (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path
+          d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2Zm0 5a3 3 0 0 1 3 3 2.73 2.73 0 0 1-1.26 2.3l-.48.32a1 1 0 0 0-.26.26.94.94 0 0 0-.12.38 1 1 0 0 1-2 0 2.81 2.81 0 0 1 .41-1.46 3.3 3.3 0 0 1 .94-.94 1 1 0 0 0 .51-.86 1 1 0 0 0-2 0 1 1 0 0 1-2 0 3 3 0 0 1 3-3Zm0 11a1.25 1.25 0 1 1 1.25-1.25A1.25 1.25 0 0 1 12 18Z"
+          fill="currentColor"
+        />
+      </svg>
+    );
   return (
-    <Modal open={open} onClose={onCancel} className="modal--confirm">
+    <Modal open={open} onClose={onCancel} className={`modal--confirm modal--confirm-${tone}`}>
+      <div className="confirm-modal__icon" aria-hidden="true">
+        {icon}
+      </div>
       <div className="modal__header">
         <h3 className="modal__title">{title}</h3>
       </div>

--- a/webapp/src/components/ConfirmModal.tsx
+++ b/webapp/src/components/ConfirmModal.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import Modal from './Modal';
+
+interface ConfirmModalProps {
+  open: boolean;
+  title: string;
+  description?: React.ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  loading?: boolean;
+  tone?: 'default' | 'danger';
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const ConfirmModal: React.FC<ConfirmModalProps> = ({
+  open,
+  title,
+  description,
+  confirmLabel = 'Подтвердить',
+  cancelLabel = 'Отмена',
+  loading = false,
+  tone = 'default',
+  onConfirm,
+  onCancel,
+}) => {
+  const confirmClass = tone === 'danger' ? 'button danger' : 'button';
+  return (
+    <Modal open={open} onClose={onCancel} className="modal--confirm">
+      <div className="modal__header">
+        <h3 className="modal__title">{title}</h3>
+      </div>
+      {description && <div className="modal__description">{description}</div>}
+      <div className="modal__actions">
+        <button className="button secondary" type="button" onClick={onCancel} disabled={loading}>
+          {cancelLabel}
+        </button>
+        <button className={confirmClass} type="button" onClick={onConfirm} disabled={loading}>
+          {loading ? 'Подождите…' : confirmLabel}
+        </button>
+      </div>
+    </Modal>
+  );
+};
+
+export default ConfirmModal;

--- a/webapp/src/components/Modal.tsx
+++ b/webapp/src/components/Modal.tsx
@@ -19,7 +19,9 @@ export default function Modal({ open, onClose, children, className }: ModalProps
   const contentClass = className ? `modal ${className}` : 'modal';
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className={contentClass} onClick={e=>e.stopPropagation()}>{children}</div>
+      <div className={contentClass} onClick={e=>e.stopPropagation()} role="dialog" aria-modal="true">
+        {children}
+      </div>
     </div>
   );
 }

--- a/webapp/src/components/Modal.tsx
+++ b/webapp/src/components/Modal.tsx
@@ -1,5 +1,13 @@
 import { ReactNode, useEffect } from "react";
-export default function Modal({ open, onClose, children }:{ open:boolean; onClose:()=>void; children:ReactNode }){
+
+interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+  className?: string;
+}
+
+export default function Modal({ open, onClose, children, className }: ModalProps) {
   useEffect(()=>{
     if(!open) return;
     const onKey=(e:KeyboardEvent)=>{ if(e.key==='Escape') onClose(); };
@@ -8,9 +16,10 @@ export default function Modal({ open, onClose, children }:{ open:boolean; onClos
   },[open,onClose]);
 
   if(!open) return null;
+  const contentClass = className ? `modal ${className}` : 'modal';
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal" onClick={e=>e.stopPropagation()}>{children}</div>
+      <div className={contentClass} onClick={e=>e.stopPropagation()}>{children}</div>
     </div>
   );
 }

--- a/webapp/src/pages/AdminPage.tsx
+++ b/webapp/src/pages/AdminPage.tsx
@@ -4,6 +4,7 @@ import { RoleInfo, Section, UserProfile } from '../types';
 import { formatDateTime } from '../utils/date';
 import SelectPill from '../components/SelectPill';
 import Modal from '../components/Modal';
+import ConfirmModal from '../components/ConfirmModal';
 
 interface AdminPageProps {
   apiClient: ApiClient;
@@ -19,6 +20,8 @@ interface UserCardProps {
   onSectionsSave: (userId: number, sections: string[]) => Promise<void>;
   onBinsSave: (userId: number, bins: string[]) => Promise<void>;
   onPasswordReset: (userId: number, password: string) => Promise<void>;
+  canDeleteUser: boolean;
+  onDeleteRequest: (user: UserProfile) => void;
 }
 
 const roleLabels: Record<string, string> = {
@@ -44,6 +47,8 @@ const AdminUserCard: React.FC<UserCardProps> = ({
   onSectionsSave,
   onBinsSave,
   onPasswordReset,
+  canDeleteUser,
+  onDeleteRequest,
 }) => {
   const [selectedRole, setSelectedRole] = useState(user.role);
   const [sectionIds, setSectionIds] = useState<Set<string>>(new Set(user.sections));
@@ -225,8 +230,14 @@ const AdminUserCard: React.FC<UserCardProps> = ({
 
   return (
     <div className="card" style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-      {/* Верхняя строка карточки */}
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr minmax(320px, 360px)', gap: 24, alignItems: 'start' }}>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'minmax(280px, 1fr) minmax(220px, 260px)',
+          gap: 24,
+          alignItems: 'start',
+        }}
+      >
         <div>
           <h3 style={{ margin: 0 }}>{user.name}</h3>
           <p className="text-muted" style={{ margin: '4px 0' }}>
@@ -242,48 +253,89 @@ const AdminUserCard: React.FC<UserCardProps> = ({
           </div>
         </div>
 
-        {/* Роль: заголовок отдельно, в пилюле только значение */}
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-          <div className="label" style={{ fontWeight: 700 }}>Роль</div>
-          <SelectPill
-            label=""                 // скрываем внутреннюю метку
-            showLabelInside={false}  // чтобы в пилюле был только value
-            options={roleOptions}
-            value={selectedRole}
-            onChange={(v) => setSelectedRole(v)}
-            style={{ minWidth: 240 }}
-          />
-          <div className="text-muted" style={{ fontSize: 12 }}>
-            {savingRole ? 'Сохраняем…' : 'Изменения сохраняются автоматически'}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+          <div>
+            <div className="label" style={{ fontWeight: 700 }}>Роль</div>
+            <SelectPill
+              label=""
+              showLabelInside={false}
+              options={roleOptions}
+              value={selectedRole}
+              onChange={(v) => setSelectedRole(v)}
+              style={{ minWidth: 220 }}
+            />
           </div>
+          {savingRole && <div className="text-muted" style={{ fontSize: 12 }}>Сохраняем…</div>}
+          {canDeleteUser && (
+            <button className="button danger" type="button" onClick={() => onDeleteRequest(user)}>
+              Удалить аккаунт
+            </button>
+          )}
         </div>
       </div>
 
-      {/* Разделы */}
-      <div>
-        <h4 style={{ marginBottom: 8 }}>Назначенные разделы</h4>
-        <div className="flex-gap" style={{ flexWrap: 'wrap', marginBottom: 10 }}>
-          {assignedSections.length === 0 && (
-            <span className="text-muted">Нет назначенных разделов</span>
-          )}
-          {assignedSections.map((section) => {
-            const label = section.title === section.id ? section.title : `${section.title} (${section.id})`;
-            return (
-              <span key={section.id} className="chip bin-chip">
-                {label}
+      <div className="assignment-grid">
+        <div>
+          <h4 style={{ marginBottom: 8 }}>Назначенные БИНы</h4>
+          <div className="flex-gap" style={{ flexWrap: 'wrap', marginBottom: 10 }}>
+            {assignedBins.length === 0 && <span className="text-muted">Нет назначенных БИНов</span>}
+            {assignedBins.map((b) => (
+              <span key={b} className="chip bin-chip">
+                {b}
                 <button
                   className="chip-x"
                   type="button"
-                  aria-label={`Удалить раздел ${label}`}
-                  onClick={() => removeSection(section.id)}
+                  aria-label={`Удалить БИН ${b}`}
+                  onClick={() => removeBin(b)}
                 >
                   ×
                 </button>
               </span>
-            );
-          })}
+            ))}
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            <div className="label" style={{ fontWeight: 700 }}>Добавить БИН</div>
+            <SelectPill
+              label=""
+              showLabelInside={false}
+              options={binOptions}
+              value={binToAdd}
+              onChange={(v) => {
+                setBinToAdd(v);
+                if (v) addBin(v);
+              }}
+              searchable
+              style={{ minWidth: 240 }}
+            />
+          </div>
+          {savingBins && (
+            <div className="text-muted" style={{ marginTop: 6, fontSize: 12 }}>Сохраняем…</div>
+          )}
         </div>
-        <div className="bins-row" style={{ justifyContent: 'flex-start' }}>
+
+        <div>
+          <h4 style={{ marginBottom: 8 }}>Назначенные разделы</h4>
+          <div className="flex-gap" style={{ flexWrap: 'wrap', marginBottom: 10 }}>
+            {assignedSections.length === 0 && (
+              <span className="text-muted">Нет назначенных разделов</span>
+            )}
+            {assignedSections.map((section) => {
+              const label = section.title || section.id;
+              return (
+                <span key={section.id} className="chip bin-chip">
+                  {label}
+                  <button
+                    className="chip-x"
+                    type="button"
+                    aria-label={`Удалить раздел ${label}`}
+                    onClick={() => removeSection(section.id)}
+                  >
+                    ×
+                  </button>
+                </span>
+              );
+            })}
+          </div>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
             <div className="label" style={{ fontWeight: 700 }}>Добавить раздел</div>
             <SelectPill
@@ -291,56 +343,17 @@ const AdminUserCard: React.FC<UserCardProps> = ({
               showLabelInside={false}
               options={sectionOptions}
               value={sectionToAdd}
-              onChange={(v) => { setSectionToAdd(v); if (v) addSection(v); }}
+              onChange={(v) => {
+                setSectionToAdd(v);
+                if (v) addSection(v);
+              }}
               searchable
-              style={{ minWidth: 260 }}
+              style={{ minWidth: 240 }}
             />
           </div>
-        </div>
-        <div className="text-muted" style={{ marginTop: 8, fontSize: 12 }}>
-          {savingSections ? 'Сохраняем…' : 'Изменения сохраняются автоматически'}
-        </div>
-      </div>
-
-      {/* БИНы */}
-      <div>
-        <h4 style={{ marginBottom: 8 }}>Назначенные БИНы</h4>
-
-        {/* селектор — слева, чипы выше уже есть; можно также отрисовывать чипы здесь, но оставим как есть */}
-        <div className="flex-gap" style={{ flexWrap: 'wrap', marginBottom: 10 }}>
-          {assignedBins.length === 0 && <span className="text-muted">Нет назначенных БИНов</span>}
-          {assignedBins.map((b) => (
-            <span key={b} className="chip bin-chip">
-              {b}
-              <button
-                className="chip-x"
-                type="button"
-                aria-label={`Удалить БИН ${b}`}
-                onClick={() => removeBin(b)}
-              >
-                ×
-              </button>
-            </span>
-          ))}
-        </div>
-
-        <div className="bins-row" style={{ justifyContent: 'flex-start' }}>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-            <div className="label" style={{ fontWeight: 700 }}>Добавить БИН</div>
-            <SelectPill
-              label=""                 // метку прячем
-              showLabelInside={false}
-              options={binOptions}
-              value={binToAdd}
-              onChange={(v) => { setBinToAdd(v); if (v) addBin(v); }}
-              searchable
-              style={{ minWidth: 260 }}
-            />
-          </div>
-        </div>
-
-        <div className="text-muted" style={{ marginTop: 8, fontSize: 12 }}>
-          {savingBins ? 'Сохраняем…' : 'Изменения сохраняются автоматически'}
+          {savingSections && (
+            <div className="text-muted" style={{ marginTop: 6, fontSize: 12 }}>Сохраняем…</div>
+          )}
         </div>
       </div>
 
@@ -390,6 +403,9 @@ const AdminPage: React.FC<AdminPageProps> = ({ apiClient, currentUser }) => {
   const [search, setSearch] = useState('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [userToDelete, setUserToDelete] = useState<UserProfile | null>(null);
+  const [deleteLoading, setDeleteLoading] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const loadAdminData = useCallback(
     async (query?: string) => {
@@ -465,6 +481,22 @@ const AdminPage: React.FC<AdminPageProps> = ({ apiClient, currentUser }) => {
     );
   }, [users, search]);
 
+  const handleConfirmDelete = useCallback(async () => {
+    if (!userToDelete) return;
+    setDeleteLoading(true);
+    setDeleteError(null);
+    try {
+      await apiClient.deleteUser(userToDelete.id);
+      setUsers((prev) => prev.filter((user) => user.id !== userToDelete.id));
+      setUserToDelete(null);
+    } catch (err) {
+      const message = err instanceof ApiError ? err.message : (err as Error)?.message ?? 'Не удалось удалить пользователя';
+      setDeleteError(message);
+    } finally {
+      setDeleteLoading(false);
+    }
+  }, [apiClient, userToDelete]);
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 24, marginBottom: 48 }}>
       <div className="card" style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
@@ -510,9 +542,37 @@ const AdminPage: React.FC<AdminPageProps> = ({ apiClient, currentUser }) => {
             onSectionsSave={handleSectionsSave}
             onBinsSave={handleBinsSave}
             onPasswordReset={handlePasswordReset}
+            canDeleteUser={currentUser.id !== user.id}
+            onDeleteRequest={(selectedUser) => {
+              setDeleteError(null);
+              setUserToDelete(selectedUser);
+            }}
           />
         ))
       )}
+
+      <ConfirmModal
+        open={Boolean(userToDelete)}
+        title="Удалить аккаунт сотрудника?"
+        description={
+          userToDelete && (
+            <>
+              Аккаунт <strong>{userToDelete.name}</strong> ({userToDelete.email}) будет удалён навсегда.
+              {deleteError && <p className="alert error" style={{ marginTop: 12 }}>{deleteError}</p>}
+            </>
+          )
+        }
+        tone="danger"
+        confirmLabel="Удалить"
+        cancelLabel="Отмена"
+        loading={deleteLoading}
+        onCancel={() => {
+          if (deleteLoading) return;
+          setUserToDelete(null);
+          setDeleteError(null);
+        }}
+        onConfirm={handleConfirmDelete}
+      />
     </div>
   );
 };

--- a/webapp/src/pages/DialogsPage.tsx
+++ b/webapp/src/pages/DialogsPage.tsx
@@ -368,6 +368,10 @@ const DialogsPage: React.FC<DialogsPageProps> = ({ apiClient, session }) => {
   }, [activeChat, chats]);
 
   const handleDialogDelete = useCallback(async () => {
+    if (!canDeleteDialog) {
+      setDialogToDelete(null);
+      return;
+    }
     if (!dialogToDelete) return;
     setDialogDeleteLoading(true);
     try {
@@ -389,7 +393,7 @@ const DialogsPage: React.FC<DialogsPageProps> = ({ apiClient, session }) => {
       setDialogDeleteLoading(false);
       setDialogToDelete(null);
     }
-  }, [activeChat, apiClient, dialogToDelete]);
+  }, [activeChat, apiClient, canDeleteDialog, dialogToDelete]);
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 24, marginBottom: 48 }}>
@@ -506,7 +510,7 @@ const DialogsPage: React.FC<DialogsPageProps> = ({ apiClient, session }) => {
       )}
 
       <ConfirmModal
-        open={Boolean(dialogToDelete)}
+        open={Boolean(dialogToDelete && canDeleteDialog)}
         title="Удалить диалог?"
         description={
           dialogToDelete

--- a/webapp/src/pages/DialogsPage.tsx
+++ b/webapp/src/pages/DialogsPage.tsx
@@ -69,6 +69,8 @@ const ChatDetailModal: React.FC<ChatDetailModalProps> = ({
       setMessages(data);
       lastCountRef.current = data.length;
       setError(null);
+      if (typeof window !== 'undefined') window.requestAnimationFrame(scrollToBottom);
+      else scrollToBottom();
     } catch (err) {
       if (err instanceof ApiError) setError(err.message);
       else if (err instanceof Error) setError(err.message);
@@ -76,7 +78,7 @@ const ChatDetailModal: React.FC<ChatDetailModalProps> = ({
     } finally {
       setLoading(false);
     }
-  }, [apiClient, chat.chatId, chat.dialogId]);
+  }, [apiClient, chat.chatId, chat.dialogId, scrollToBottom]);
 
   useEffect(() => { loadMessages(); }, [loadMessages]);
 
@@ -100,6 +102,8 @@ const ChatDetailModal: React.FC<ChatDetailModalProps> = ({
         if (data.length !== lastCountRef.current) {
           setMessages(data);
           lastCountRef.current = data.length;
+          if (typeof window !== 'undefined') window.requestAnimationFrame(scrollToBottom);
+          else scrollToBottom();
         }
       } catch {
         /* игнорируем */
@@ -109,7 +113,7 @@ const ChatDetailModal: React.FC<ChatDetailModalProps> = ({
     return () => {
       if (pollRef.current) window.clearInterval(pollRef.current);
     };
-  }, [apiClient, chat.chatId, chat.dialogId]);
+  }, [apiClient, chat.chatId, chat.dialogId, scrollToBottom]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
@@ -146,7 +150,7 @@ const ChatDetailModal: React.FC<ChatDetailModalProps> = ({
 
   return (
     <Modal open onClose={onClose} className="modal--dialog">
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 16, maxHeight: '70vh' }}>
+      <div className="dialog-modal__layout">
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 16 }}>
           <div>
             <h2 className="heading" style={{ marginBottom: 6 }}>{chat.title}</h2>
@@ -185,9 +189,11 @@ const ChatDetailModal: React.FC<ChatDetailModalProps> = ({
         <div className="separator" />
         {error && <div className="alert">{error}</div>}
 
-        <div style={{ flex: 1, overflow: 'hidden' }}>
+        <div className="dialog-modal__scroll">
           {loading ? (
-            <div style={{ padding: '24px 0', textAlign: 'center' }}>Загружаем сообщения...</div>
+            <div className="message-list" aria-busy="true">
+              <div style={{ margin: 'auto', textAlign: 'center', width: '100%' }}>Загружаем сообщения...</div>
+            </div>
           ) : (
             <div className="message-list" ref={listRef}>
               {messages.length === 0 && <div className="text-muted">Нет сообщений в этом диалоге.</div>}

--- a/webapp/src/pages/DialogsPage.tsx
+++ b/webapp/src/pages/DialogsPage.tsx
@@ -4,6 +4,8 @@ import { AuthSession, ChatSummary, Message, MessageNotification, Section } from 
 import { formatDateTime } from '../utils/date';
 import SelectPill from "../components/SelectPill";
 import StarButton from "../components/StarButton";
+import Modal from "../components/Modal";
+import ConfirmModal from "../components/ConfirmModal";
 
 /* -------------------- Props -------------------- */
 interface DialogsPageProps {
@@ -16,17 +18,24 @@ interface ChatDetailModalProps {
   chat: ChatSummary;
   onClose: () => void;
   onChatUpdated: (chat: ChatSummary) => void;
-  onChatDeleted: (chatId: number) => void;
+  canDeleteDialog: boolean;
+  onDeleteRequest: (chat: ChatSummary) => void;
 }
 
 /* -------------------- Modal -------------------- */
-const ChatDetailModal: React.FC<ChatDetailModalProps> = ({ apiClient, chat, onClose, onChatUpdated, onChatDeleted }) => {
+const ChatDetailModal: React.FC<ChatDetailModalProps> = ({
+  apiClient,
+  chat,
+  onClose,
+  onChatUpdated,
+  canDeleteDialog,
+  onDeleteRequest,
+}) => {
   const [messages, setMessages] = useState<Message[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [input, setInput] = useState('');
   const [sending, setSending] = useState(false);
-  const [deleting, setDeleting] = useState(false);
 
   const listRef = useRef<HTMLDivElement>(null);
   const pollRef = useRef<number | null>(null);
@@ -43,7 +52,7 @@ const ChatDetailModal: React.FC<ChatDetailModalProps> = ({ apiClient, chat, onCl
   const loadMessages = useCallback(async () => {
     try {
       setLoading(true);
-      const data = await apiClient.fetchMessages(chat.chatId, 200);
+      const data = await apiClient.fetchMessages(chat.chatId, 200, chat.dialogId);
       setMessages(data);
       lastCountRef.current = data.length;
       setError(null);
@@ -54,21 +63,19 @@ const ChatDetailModal: React.FC<ChatDetailModalProps> = ({ apiClient, chat, onCl
     } finally {
       setLoading(false);
     }
-  }, [apiClient, chat.chatId]);
+  }, [apiClient, chat.chatId, chat.dialogId]);
 
   useEffect(() => { loadMessages(); }, [loadMessages]);
 
-  // ВСЕГДА скроллим вниз, когда массив messages обновился (открытие, пуллинг, отправка и т.п.)
   useEffect(() => {
     const t = setTimeout(scrollToBottom, 0);
     return () => clearTimeout(t);
   }, [messages, scrollToBottom]);
 
-  // Пуллинг новых сообщений, пока модалка открыта
   useEffect(() => {
     pollRef.current = window.setInterval(async () => {
       try {
-        const data = await apiClient.fetchMessages(chat.chatId, 200);
+        const data = await apiClient.fetchMessages(chat.chatId, 200, chat.dialogId);
         if (data.length !== lastCountRef.current) {
           setMessages(data);
           lastCountRef.current = data.length;
@@ -81,9 +88,8 @@ const ChatDetailModal: React.FC<ChatDetailModalProps> = ({ apiClient, chat, onCl
     return () => {
       if (pollRef.current) window.clearInterval(pollRef.current);
     };
-  }, [apiClient, chat.chatId]);
+  }, [apiClient, chat.chatId, chat.dialogId]);
 
-  // Esc для закрытия
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
     document.addEventListener('keydown', onKey);
@@ -94,9 +100,8 @@ const ChatDetailModal: React.FC<ChatDetailModalProps> = ({ apiClient, chat, onCl
     if (!input.trim()) return;
     setSending(true);
     try {
-      await apiClient.sendMessage(chat.chatId, input.trim());
+      await apiClient.sendMessage(chat.chatId, input.trim(), chat.dialogId);
       setInput('');
-      // моментально обновим список, чтобы сообщение появилось сразу
       await loadMessages();
     } catch (err) {
       if (err instanceof ApiError) setError(err.message);
@@ -118,47 +123,21 @@ const ChatDetailModal: React.FC<ChatDetailModalProps> = ({ apiClient, chat, onCl
     }
   };
 
-  const deleteChat = async () => {
-    if (!window.confirm('Удалить диалог без возможности восстановления?')) return;
-    setDeleting(true);
-    try {
-      await apiClient.deleteChat(chat.chatId);
-      onChatDeleted(chat.chatId);
-      onClose();
-    } catch (err) {
-      if (err instanceof ApiError) setError(err.message);
-      else if (err instanceof Error) setError(err.message);
-    } finally {
-      setDeleting(false);
-    }
-  };
-
   return (
-    <div
-      style={{
-        position: 'fixed',
-        inset: 0,
-        background: 'rgba(20, 30, 60, 0.55)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        zIndex: 1000,
-        padding: 24,
-      }}
-      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
-    >
-      <div className="card" style={{ width: 'min(980px, 100%)', maxHeight: '90vh', display: 'flex', flexDirection: 'column', position: 'relative' }}>
-        {/* header */}
+    <Modal open onClose={onClose} className="modal--dialog">
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 16, maxHeight: '70vh' }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 16 }}>
           <div>
             <h2 className="heading" style={{ marginBottom: 6 }}>{chat.title}</h2>
             <div className="text-muted" style={{ fontSize: '0.9rem' }}>
               {chat.username ? `@${chat.username}` : chat.type}
             </div>
-            <div className="flex-gap" style={{ marginTop: 12 }}>
+            <div className="dialog-meta" style={{ marginTop: 12 }}>
               {chat.sectionTitle && <span className="chip">Раздел: {chat.sectionTitle}</span>}
               {chat.bin && <span className="chip">БИН: {chat.bin}</span>}
+              <span className="chip">Начат: {formatDateTime(chat.dialogStartedAt)}</span>
               <span className="chip">Обновлён: {formatDateTime(chat.updatedAt)}</span>
+              {chat.dialogClosedAt && <span className="chip">Закрыт: {formatDateTime(chat.dialogClosedAt)}</span>}
             </div>
           </div>
 
@@ -168,7 +147,15 @@ const ChatDetailModal: React.FC<ChatDetailModalProps> = ({ apiClient, chat, onCl
               onToggle={toggleFavorite}
               title={chat.isFavorite ? "Убрать из избранного" : "В избранное"}
             />
-            {/* крестик */}
+            {canDeleteDialog && (
+              <button
+                className="button danger"
+                type="button"
+                onClick={() => onDeleteRequest(chat)}
+              >
+                Удалить
+              </button>
+            )}
             <button
               className="icon-btn"
               type="button"
@@ -186,34 +173,35 @@ const ChatDetailModal: React.FC<ChatDetailModalProps> = ({ apiClient, chat, onCl
         <div className="separator" />
         {error && <div className="alert">{error}</div>}
 
-        {loading ? (
-          <div style={{ padding: '24px 0', textAlign: 'center' }}>Загружаем сообщения...</div>
-        ) : (
-          <div className="message-list" ref={listRef}>
-            {messages.length === 0 && <div className="text-muted">Нет сообщений в этом диалоге.</div>}
-            {messages.map((message) => (
-              <div
-                key={message.id}
-                className={`message-bubble ${message.direction}`}
-                style={{ alignSelf: message.direction === 'incoming' ? 'flex-start' : 'flex-end' }}
-              >
-                {message.author && <div style={{ fontWeight: 600, marginBottom: 6, opacity: 0.85 }}>{message.author}</div>}
-                <div>{message.text}</div>
-                <div style={{ marginTop: 6, fontSize: '0.75rem', opacity: 0.7 }}>{formatDateTime(message.createdAt)}</div>
-                {message.sectionTitle && (
-                  <div style={{ marginTop: 6, fontSize: '0.75rem', opacity: 0.7 }}>Раздел: {message.sectionTitle}</div>
-                )}
-              </div>
-            ))}
-          </div>
-        )}
+        <div style={{ flex: 1, overflow: 'hidden' }}>
+          {loading ? (
+            <div style={{ padding: '24px 0', textAlign: 'center' }}>Загружаем сообщения...</div>
+          ) : (
+            <div className="message-list" ref={listRef}>
+              {messages.length === 0 && <div className="text-muted">Нет сообщений в этом диалоге.</div>}
+              {messages.map((message) => (
+                <div
+                  key={message.id}
+                  className={`message-bubble ${message.direction}`}
+                  style={{ alignSelf: message.direction === 'incoming' ? 'flex-start' : 'flex-end' }}
+                >
+                  {message.author && <div style={{ fontWeight: 600, marginBottom: 6, opacity: 0.85 }}>{message.author}</div>}
+                  <div>{message.text}</div>
+                  <div style={{ marginTop: 6, fontSize: '0.75rem', opacity: 0.7 }}>{formatDateTime(message.createdAt)}</div>
+                  {message.sectionTitle && (
+                    <div style={{ marginTop: 6, fontSize: '0.75rem', opacity: 0.7 }}>Раздел: {message.sectionTitle}</div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
 
         <div className="separator" />
-        {/* footer */}
-        <div style={{ display: 'flex', gap: 12 }}>
+        <div className="dialog-composer">
           <textarea
             className="textarea"
-            placeholder={canReply ? 'Ваш ответ оператору...' : 'У вашей роли нет прав для ответа.'}
+            placeholder={canReply ? 'Ваш ответ клиенту…' : 'У вашей роли нет прав для ответа.'}
             value={input}
             onChange={(event) => setInput(event.target.value)}
             onKeyDown={(e) => {
@@ -222,17 +210,17 @@ const ChatDetailModal: React.FC<ChatDetailModalProps> = ({ apiClient, chat, onCl
                 handleSend();
               }
             }}
-            disabled={!canReply || sending || deleting}
+            disabled={!canReply || sending}
             rows={3}
           />
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-            <button className="button" type="button" onClick={handleSend} disabled={!canReply || sending || deleting}>
-              {sending ? 'Отправляем...' : 'Отправить'}
+          <div className="dialog-composer__actions">
+            <button className="button" type="button" onClick={handleSend} disabled={!canReply || sending || !input.trim()}>
+              {sending ? 'Отправляем…' : 'Отправить'}
             </button>
           </div>
         </div>
       </div>
-    </div>
+    </Modal>
   );
 };
 
@@ -250,9 +238,12 @@ const DialogsPage: React.FC<DialogsPageProps> = ({ apiClient, session }) => {
 
   const [banner, setBanner] = useState<string | null>(null);
   const [activeChat, setActiveChat] = useState<ChatSummary | null>(null);
+  const [dialogToDelete, setDialogToDelete] = useState<ChatSummary | null>(null);
+  const [dialogDeleteLoading, setDialogDeleteLoading] = useState(false);
   const [updatesCursor, setUpdatesCursor] = useState<Date | null>(null);
 
   const currentUser = session.user;
+  const canDeleteDialog = currentUser.isAdmin;
 
   const loadSectionsAndChats = useCallback(
     async (withLoading = true, overrides?: { bin?: string | null; favoritesOnly?: boolean }) => {
@@ -364,6 +355,42 @@ const DialogsPage: React.FC<DialogsPageProps> = ({ apiClient, session }) => {
     return list.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
   }, [apiClient.currentUser?.favoriteChatIds, chats, selectedSection, showFavoritesOnly]);
 
+  useEffect(() => {
+    if (!activeChat) return;
+    const updated = chats.find((item) => item.dialogId === activeChat.dialogId);
+    if (!updated) {
+      setActiveChat(null);
+      return;
+    }
+    if (updated !== activeChat) {
+      setActiveChat(updated);
+    }
+  }, [activeChat, chats]);
+
+  const handleDialogDelete = useCallback(async () => {
+    if (!dialogToDelete) return;
+    setDialogDeleteLoading(true);
+    try {
+      await apiClient.deleteDialog(dialogToDelete.dialogId);
+      setChats((prev) => prev.filter((item) => item.dialogId !== dialogToDelete.dialogId));
+      if (activeChat?.dialogId === dialogToDelete.dialogId) {
+        setActiveChat(null);
+      }
+      setBanner('Диалог удалён');
+    } catch (err) {
+      const message =
+        err instanceof ApiError
+          ? err.message
+          : err instanceof Error
+          ? err.message
+          : 'Не удалось удалить диалог.';
+      setBanner(`Ошибка: ${message}`);
+    } finally {
+      setDialogDeleteLoading(false);
+      setDialogToDelete(null);
+    }
+  }, [activeChat, apiClient, dialogToDelete]);
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 24, marginBottom: 48 }}>
       {banner && (<div className="alert" onAnimationEnd={() => setBanner(null)}>{banner}</div>)}
@@ -412,7 +439,11 @@ const DialogsPage: React.FC<DialogsPageProps> = ({ apiClient, session }) => {
         </div>
       ) : (
         filteredChats.map((chat) => (
-          <div key={chat.chatId} className="card" style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+          <div
+            key={`${chat.chatId}-${chat.dialogId}`}
+            className="card"
+            style={{ display: 'flex', flexDirection: 'column', gap: 12 }}
+          >
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12 }}>
               <div>
                 <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
@@ -443,20 +474,11 @@ const DialogsPage: React.FC<DialogsPageProps> = ({ apiClient, session }) => {
                 <button className="button" type="button" onClick={() => setActiveChat(chat)}>
                   Открыть диалог
                 </button>
-                {(currentUser.isAdmin || currentUser.canReply) && (
+                {canDeleteDialog && (
                   <button
-                    className="button secondary"
+                    className="button danger"
                     type="button"
-                    onClick={async () => {
-                      if (window.confirm('Удалить диалог?')) {
-                        try {
-                          await apiClient.deleteChat(chat.chatId);
-                          setChats((prev) => prev.filter((item) => item.chatId !== chat.chatId));
-                        } catch (err) {
-                          if (err instanceof ApiError) alert(err.message);
-                        }
-                      }
-                    }}
+                    onClick={() => setDialogToDelete(chat)}
                   >
                     Удалить
                   </button>
@@ -473,15 +495,36 @@ const DialogsPage: React.FC<DialogsPageProps> = ({ apiClient, session }) => {
           chat={activeChat}
           onClose={() => setActiveChat(null)}
           onChatUpdated={(updated) => {
-            setChats((prev) => prev.map((item) => (item.chatId === updated.chatId ? updated : item)));
-            setActiveChat(updated);
+            setChats((prev) =>
+              prev.map((item) => (item.dialogId === updated.dialogId ? updated : item)),
+            );
+            setActiveChat((prev) => (prev && prev.dialogId === updated.dialogId ? updated : prev));
           }}
-          onChatDeleted={(chatId) => {
-            setChats((prev) => prev.filter((item) => item.chatId !== chatId));
-            setActiveChat(null);
-          }}
+          canDeleteDialog={canDeleteDialog}
+          onDeleteRequest={(chat) => setDialogToDelete(chat)}
         />
       )}
+
+      <ConfirmModal
+        open={Boolean(dialogToDelete)}
+        title="Удалить диалог?"
+        description={
+          dialogToDelete
+            ? (
+              <>
+                Диалог с <strong>{dialogToDelete.title}</strong> будет удалён навсегда.
+                Это действие нельзя отменить.
+              </>
+            )
+            : undefined
+        }
+        tone="danger"
+        confirmLabel="Удалить"
+        cancelLabel="Отмена"
+        loading={dialogDeleteLoading}
+        onCancel={() => setDialogToDelete(null)}
+        onConfirm={handleDialogDelete}
+      />
     </div>
   );
 };

--- a/webapp/src/pages/DialogsPage.tsx
+++ b/webapp/src/pages/DialogsPage.tsx
@@ -1,4 +1,11 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { ApiClient, ApiError } from '../api/ApiClient';
 import { AuthSession, ChatSummary, Message, MessageNotification, Section } from '../types';
 import { formatDateTime } from '../utils/date';
@@ -18,8 +25,6 @@ interface ChatDetailModalProps {
   chat: ChatSummary;
   onClose: () => void;
   onChatUpdated: (chat: ChatSummary) => void;
-  canDeleteDialog: boolean;
-  onDeleteRequest: (chat: ChatSummary) => void;
 }
 
 /* -------------------- Modal -------------------- */
@@ -28,8 +33,6 @@ const ChatDetailModal: React.FC<ChatDetailModalProps> = ({
   chat,
   onClose,
   onChatUpdated,
-  canDeleteDialog,
-  onDeleteRequest,
 }) => {
   const [messages, setMessages] = useState<Message[]>([]);
   const [loading, setLoading] = useState(false);
@@ -40,9 +43,19 @@ const ChatDetailModal: React.FC<ChatDetailModalProps> = ({
   const listRef = useRef<HTMLDivElement>(null);
   const pollRef = useRef<number | null>(null);
   const lastCountRef = useRef<number>(0);
+  const composerRef = useRef<HTMLTextAreaElement>(null);
 
   const currentUser = apiClient.currentUser;
   const canReply = Boolean(currentUser?.canReply);
+
+  const adjustComposerHeight = useCallback(() => {
+    const el = composerRef.current;
+    if (!el) return;
+    const minHeight = 52;
+    el.style.height = 'auto';
+    const nextHeight = Math.max(el.scrollHeight, minHeight);
+    el.style.height = `${nextHeight}px`;
+  }, []);
 
   const scrollToBottom = useCallback(() => {
     const el = listRef.current;
@@ -66,6 +79,14 @@ const ChatDetailModal: React.FC<ChatDetailModalProps> = ({
   }, [apiClient, chat.chatId, chat.dialogId]);
 
   useEffect(() => { loadMessages(); }, [loadMessages]);
+
+  useLayoutEffect(() => {
+    adjustComposerHeight();
+  }, [adjustComposerHeight, input]);
+
+  useLayoutEffect(() => {
+    adjustComposerHeight();
+  }, [adjustComposerHeight, chat.dialogId]);
 
   useEffect(() => {
     const t = setTimeout(scrollToBottom, 0);
@@ -147,15 +168,6 @@ const ChatDetailModal: React.FC<ChatDetailModalProps> = ({
               onToggle={toggleFavorite}
               title={chat.isFavorite ? "Убрать из избранного" : "В избранное"}
             />
-            {canDeleteDialog && (
-              <button
-                className="button danger"
-                type="button"
-                onClick={() => onDeleteRequest(chat)}
-              >
-                Удалить
-              </button>
-            )}
             <button
               className="icon-btn"
               type="button"
@@ -210,8 +222,10 @@ const ChatDetailModal: React.FC<ChatDetailModalProps> = ({
                 handleSend();
               }
             }}
+            onInput={adjustComposerHeight}
             disabled={!canReply || sending}
-            rows={3}
+            rows={1}
+            ref={composerRef}
           />
           <div className="dialog-composer__actions">
             <button className="button" type="button" onClick={handleSend} disabled={!canReply || sending || !input.trim()}>
@@ -504,8 +518,6 @@ const DialogsPage: React.FC<DialogsPageProps> = ({ apiClient, session }) => {
             );
             setActiveChat((prev) => (prev && prev.dialogId === updated.dialogId ? updated : prev));
           }}
-          canDeleteDialog={canDeleteDialog}
-          onDeleteRequest={(chat) => setDialogToDelete(chat)}
         />
       )}
 

--- a/webapp/src/pages/ProfilePage.tsx
+++ b/webapp/src/pages/ProfilePage.tsx
@@ -13,10 +13,11 @@ interface ProfilePageProps {
 const ProfilePage: React.FC<ProfilePageProps> = ({ apiClient, session, onSessionUpdate }) => {
   const user = session.user;
 
-  const [name, setName] = useState((user as any).name || '');
-  const [position, setPosition] = useState((user as any).jobTitle || '');
-  const [phone, setPhone] = useState((user as any).phone || '');
-  const [bio, setBio] = useState((user as any).bio || '');
+  const [name, setName] = useState(user.name || '');
+  const [email, setEmail] = useState(user.email || '');
+  const [position, setPosition] = useState(user.jobTitle || '');
+  const [phone, setPhone] = useState(user.phone || '');
+  const [bio, setBio] = useState(user.bio || '');
 
   const [saving, setSaving] = useState(false);
   const [banner, setBanner] = useState<string | null>(null);
@@ -55,12 +56,18 @@ const ProfilePage: React.FC<ProfilePageProps> = ({ apiClient, session, onSession
     try {
       const updated = await apiClient.updateProfile({
         name: name.trim(),
+        email: email.trim(),
         jobTitle: position.trim(),
         phone: phone.trim(),
         bio: bio.trim(),
       });
       // обновим сессию, чтобы хедер и др. места сразу получили актуальные данные
       onSessionUpdate({ ...session, user: { ...session.user, ...updated } });
+      setName(updated.name || '');
+      setEmail(updated.email || '');
+      setPosition(updated.jobTitle || '');
+      setPhone(updated.phone || '');
+      setBio(updated.bio || '');
       setBanner('Профиль обновлён');
     } catch (e) {
       const msg = e instanceof ApiError ? e.message : (e as Error)?.message ?? 'Не удалось сохранить профиль';
@@ -119,20 +126,42 @@ const ProfilePage: React.FC<ProfilePageProps> = ({ apiClient, session, onSession
           {/* Кнопку "Обновить из сервера" убрали по ТЗ */}
         </div>
 
-        <label className="label">
-          Имя и фамилия
-          <input className="input" value={name} onChange={e => setName(e.target.value)} />
-        </label>
+        <div className="profile-form-grid">
+          <label className="label">
+            Имя и фамилия
+            <input className="input" value={name} onChange={e => setName(e.target.value)} autoComplete="name" />
+          </label>
 
-        <label className="label">
-          Должность
-          <input className="input" value={position} onChange={e => setPosition(e.target.value)} />
-        </label>
+          <label className="label">
+            Электронная почта
+            <input
+              className="input"
+              type="email"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              autoComplete="email"
+              placeholder="name@example.com"
+            />
+          </label>
 
-        <label className="label">
-          Телефон
-          <input className="input" value={phone} onChange={e => setPhone(e.target.value)} placeholder="+7 (777) 000-00-00" />
-        </label>
+          <label className="label">
+            Должность
+            <input className="input" value={position} onChange={e => setPosition(e.target.value)} autoComplete="organization-title" />
+          </label>
+
+          <label className="label">
+            Телефон
+            <input
+              className="input"
+              type="tel"
+              inputMode="tel"
+              value={phone}
+              onChange={e => setPhone(e.target.value)}
+              placeholder="+7 (777) 000-00-00"
+              autoComplete="tel"
+            />
+          </label>
+        </div>
 
         <label className="label">
           О себе и компетенции

--- a/webapp/src/pages/ProfilePage.tsx
+++ b/webapp/src/pages/ProfilePage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { ApiClient, ApiError } from '../api/ApiClient';
-import { AuthSession } from '../types';
+import { AuthSession, Section } from '../types';
 import Modal from '../components/Modal';
 
 interface ProfilePageProps {
@@ -22,6 +22,8 @@ const ProfilePage: React.FC<ProfilePageProps> = ({ apiClient, session, onSession
   const [saving, setSaving] = useState(false);
   const [banner, setBanner] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  const [sectionTitles, setSectionTitles] = useState<Record<string, string>>({});
 
   // ======== Модалка смены пароля ========
   const [pwdOpen, setPwdOpen] = useState(false);
@@ -49,6 +51,36 @@ const ProfilePage: React.FC<ProfilePageProps> = ({ apiClient, session, onSession
   }, [banner]);
 
   const isAdmin = useMemo(() => user.role === 'admin', [user.role]);
+
+  useEffect(() => {
+    if (isAdmin) {
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const availableSections: Section[] = await apiClient.fetchSections();
+        if (cancelled) {
+          return;
+        }
+        const titles = availableSections.reduce<Record<string, string>>((acc, section) => {
+          acc[section.id] = section.title;
+          return acc;
+        }, {});
+        setSectionTitles(titles);
+      } catch (err) {
+        console.warn('Не удалось загрузить список разделов', err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [apiClient, isAdmin]);
+
+  const assignedSections = useMemo(
+    () => (user.sections ?? []).map((sectionId) => sectionTitles[sectionId] ?? sectionId),
+    [sectionTitles, user.sections],
+  );
 
   const saveProfile = async () => {
     setSaving(true);
@@ -189,9 +221,17 @@ const ProfilePage: React.FC<ProfilePageProps> = ({ apiClient, session, onSession
         <>
           <div className="card">
             <h3>Назначенные разделы</h3>
-            {user.sections?.length ? (
+            {assignedSections.length ? (
               <div className="flex-gap" style={{ flexWrap: 'wrap' }}>
-                {user.sections.map((s) => <span key={s} className="chip">{s}</span>)}
+                {assignedSections.map((title, index) => {
+                  const sectionId = user.sections[index];
+                  const key = sectionId ?? `${title}-${index}`;
+                  return (
+                    <span key={key} className="chip">
+                      {title}
+                    </span>
+                  );
+                })}
               </div>
             ) : (
               <p className="text-muted">Разделы ещё не назначены. Обратитесь к администратору.</p>

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -75,6 +75,7 @@ select {
   border: 1px solid rgba(62, 90, 168, 0.35);
   background-color: rgba(255, 255, 255, 0.9);
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  resize: vertical;
 }
 
 .input:focus,
@@ -257,12 +258,60 @@ select {
 .star svg{width:16px;height:16px;fill:#cbd3ff}
 .star.active svg{fill:#f5b301}
 
-/* модалка */
-.modal-overlay{position:fixed;inset:0;background:rgba(7,12,29,.45);display:flex;align-items:center;justify-content:center;z-index:40}
-.modal{width:100%;max-width:420px;background:#fff;border:1px solid #e8ecff;border-radius:16px;padding:18px;box-shadow:0 18px 44px rgba(17,23,60,.18)}
-.modal h3{margin:0 0 10px 0}
-.modal .row{display:flex;flex-direction:column;gap:6px;margin:10px 0}
-.modal .actions{display:flex;gap:10px;justify-content:flex-end;margin-top:6px}
+/* модальные окна */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(2px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 40;
+}
+
+.modal {
+  width: min(560px, 100%);
+  background: #ffffff;
+  border-radius: 20px;
+  box-shadow: 0 28px 60px rgba(15, 23, 42, 0.24);
+  padding: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.modal__title {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: #253263;
+}
+
+.modal__description {
+  margin: 0;
+  color: #525b7c;
+  line-height: 1.5;
+}
+
+.modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.modal--confirm {
+  max-width: 420px;
+  gap: 16px;
+}
 
 /* служебное */
 .sticky-filters{position:sticky;top:12px;z-index:5}
@@ -439,3 +488,54 @@ html, body {
 .chip-x:hover{ box-shadow:0 0 0 4px rgba(64,80,160,.08); color:#2f4390; }
 
 
+
+.button.danger {
+  background-color: #d14343;
+  border-color: transparent;
+}
+
+.button.danger:hover:not(:disabled) {
+  background-color: #b93636;
+}
+
+.dialog-composer {
+  display: flex;
+  gap: 12px;
+  align-items: stretch;
+}
+
+.dialog-composer textarea {
+  flex: 1;
+  min-height: 140px;
+  resize: vertical;
+}
+
+.dialog-composer__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 140px;
+}
+
+.dialog-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.assignment-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: start;
+}
+
+.profile-form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+}
+
+.modal--dialog {
+  max-width: 900px;
+}

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -534,21 +534,30 @@ html, body {
 
 .dialog-composer {
   display: flex;
+  flex-wrap: wrap;
   gap: 12px;
-  align-items: stretch;
+  align-items: flex-end;
 }
 
 .dialog-composer textarea {
-  flex: 1;
-  min-height: 140px;
-  resize: vertical;
+  flex: 1 1 260px;
+  max-width: 280px;
+  width: 100%;
+  min-height: 52px;
+  resize: none;
+  overflow: hidden;
+  line-height: 1.5;
 }
 
 .dialog-composer__actions {
   display: flex;
-  flex-direction: column;
-  gap: 8px;
-  min-width: 140px;
+  flex: 1 1 260px;
+  max-width: 280px;
+  width: 100%;
+}
+
+.dialog-composer__actions .button {
+  flex: 1;
 }
 
 .dialog-meta {

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -211,8 +211,10 @@ select {
   flex-direction: column;
   gap: 12px;
   padding: 16px;
-  max-height: 60vh;
   overflow-y: auto;
+  flex: 1 1 auto;
+  min-height: 0;
+  width: 100%;
 }
 
 .message-bubble {
@@ -269,6 +271,7 @@ select {
   justify-content: center;
   padding: 24px;
   z-index: 40;
+  overflow-y: auto;
 }
 
 .modal {
@@ -280,6 +283,8 @@ select {
   display: flex;
   flex-direction: column;
   gap: 20px;
+  max-height: calc(100vh - 48px);
+  overflow: hidden;
 }
 
 .modal__header {
@@ -533,15 +538,13 @@ html, body {
 }
 
 .dialog-composer {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: 12px;
   align-items: flex-end;
 }
 
 .dialog-composer textarea {
-  flex: 1 1 260px;
-  max-width: 280px;
   width: 100%;
   min-height: 52px;
   resize: none;
@@ -551,13 +554,11 @@ html, body {
 
 .dialog-composer__actions {
   display: flex;
-  flex: 1 1 260px;
-  max-width: 280px;
-  width: 100%;
+  align-items: stretch;
 }
 
 .dialog-composer__actions .button {
-  flex: 1;
+  white-space: nowrap;
 }
 
 .dialog-meta {
@@ -580,5 +581,20 @@ html, body {
 }
 
 .modal--dialog {
-  max-width: 900px;
+  width: min(900px, 100%);
+  max-height: calc(100vh - 48px);
+}
+
+.dialog-modal__layout {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  height: 100%;
+}
+
+.dialog-modal__scroll {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  width: 100%;
 }

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -311,6 +311,40 @@ select {
 .modal--confirm {
   max-width: 420px;
   gap: 16px;
+  text-align: left;
+}
+
+.modal--confirm .modal__header {
+  padding: 0;
+}
+
+.confirm-modal__icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 16px;
+  display: grid;
+  place-items: center;
+  background: var(--brand-200);
+  color: var(--brand);
+  margin-bottom: 4px;
+}
+
+.confirm-modal__icon svg {
+  width: 28px;
+  height: 28px;
+}
+
+.modal--confirm-danger .confirm-modal__icon {
+  background: #fee2e2;
+  color: #d03838;
+}
+
+.modal--confirm-danger .modal__title {
+  color: #d03838;
+}
+
+.modal--confirm-danger .modal__description {
+  color: #4a1f1f;
 }
 
 /* служебное */

--- a/webapp/src/types.ts
+++ b/webapp/src/types.ts
@@ -25,10 +25,13 @@ export interface Section {
 
 export interface ChatSummaryRaw {
   chat_id: number;
+  dialog_id: number;
   title: string;
   username?: string | null;
   type: string;
   updated_at: string;
+  dialog_started_at: string;
+  dialog_closed_at?: string | null;
   section?: string | null;
   section_title?: string | null;
   bin?: string | null;
@@ -44,6 +47,7 @@ export interface MessageRaw {
   created_at: string;
   section?: string | null;
   section_title?: string | null;
+  dialog_id?: number | null;
 }
 
 export interface MessageNotificationRaw {
@@ -55,6 +59,7 @@ export interface MessageNotificationRaw {
   section?: string | null;
   section_title?: string | null;
   bin?: string | null;
+  dialog_id?: number | null;
 }
 
 export interface RoleInfo {
@@ -86,10 +91,13 @@ export interface AuthSession {
 
 export interface ChatSummary {
   chatId: number;
+  dialogId: number;
   title: string;
   username?: string | null;
   type: string;
   updatedAt: Date;
+  dialogStartedAt: Date;
+  dialogClosedAt: Date | null;
   section?: string | null;
   sectionTitle?: string | null;
   bin?: string | null;
@@ -105,6 +113,7 @@ export interface Message {
   createdAt: Date;
   section?: string | null;
   sectionTitle?: string | null;
+  dialogId?: number | null;
 }
 
 export interface MessageNotification {
@@ -116,4 +125,5 @@ export interface MessageNotification {
   section?: string | null;
   sectionTitle?: string | null;
   bin?: string | null;
+  dialogId?: number | null;
 }

--- a/webapp/src/utils/converters.ts
+++ b/webapp/src/utils/converters.ts
@@ -43,10 +43,13 @@ export function mapSession(raw: AuthSessionRaw): AuthSession {
 export function mapChatSummary(raw: ChatSummaryRaw): ChatSummary {
   return {
     chatId: raw.chat_id,
+    dialogId: raw.dialog_id,
     title: raw.title,
     username: raw.username ?? null,
     type: raw.type,
     updatedAt: new Date(raw.updated_at),
+    dialogStartedAt: new Date(raw.dialog_started_at),
+    dialogClosedAt: raw.dialog_closed_at ? new Date(raw.dialog_closed_at) : null,
     section: raw.section ?? null,
     sectionTitle: raw.section_title ?? null,
     bin: raw.bin ?? null,
@@ -64,6 +67,7 @@ export function mapMessage(raw: MessageRaw): Message {
     createdAt: new Date(raw.created_at),
     section: raw.section ?? null,
     sectionTitle: raw.section_title ?? null,
+    dialogId: raw.dialog_id ?? null,
   };
 }
 
@@ -77,5 +81,6 @@ export function mapNotification(raw: MessageNotificationRaw): MessageNotificatio
     section: raw.section ?? null,
     sectionTitle: raw.section_title ?? null,
     bin: raw.bin ?? null,
+    dialogId: raw.dialog_id ?? null,
   };
 }

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -5,5 +5,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 5173,
+    host: '0.0.0.0',
   }
 });

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -6,5 +6,9 @@ export default defineConfig({
   server: {
     port: 5173,
     host: '0.0.0.0',
-  }
+  },
+  preview: {
+    port: 4173,
+    host: '0.0.0.0',
+  },
 });


### PR DESCRIPTION
## Summary
- persist Telegram conversations as dialog records tied to BIN assignments and expose dialog-aware APIs for messages and deletion
- add reusable confirmation modal, enforce admin-only deletion for dialogs and staff accounts, and refresh dialogs/admin UI accordingly
- extend the profile flow with email/phone editing and hide the profile tab while keeping the avatar shortcut; bind dev server to 0.0.0.0 for remote access

## Testing
- npm --prefix webapp run build *(fails: sh: 1: vite: Permission denied due to repository-provided Windows binary)*

------
https://chatgpt.com/codex/tasks/task_e_68edd1f70b988327b38d14280af4fdc3